### PR TITLE
feat: adicionar telas de visitantes, pets e veículos

### DIFF
--- a/components/AplicativoCondominio.tsx
+++ b/components/AplicativoCondominio.tsx
@@ -15,6 +15,9 @@ import { PaginaRelatorios } from './paginas/PaginaRelatorios';
 import { PaginaAvaliacao } from './paginas/PaginaAvaliacao';
 import { PaginaUsuarios } from './paginas/PaginaUsuarios';
 import { PaginaConfiguracoes } from './paginas/PaginaConfiguracoes';
+import { PaginaVisitantes } from './paginas/PaginaVisitantes';
+import { PaginaPets } from './paginas/PaginaPets';
+import { PaginaVeiculos } from './paginas/PaginaVeiculos';
 
 // Páginas placeholder para outras funcionalidades
 function PaginaPlaceholder({ titulo }: { titulo: string }) {
@@ -78,6 +81,12 @@ export function AplicativoCondominio() {
         return <PaginaAvaliacao />;
       case 'usuarios':
         return <PaginaUsuarios />;
+      case 'visitantes':
+        return <PaginaVisitantes />;
+      case 'pets':
+        return <PaginaPets />;
+      case 'veiculos':
+        return <PaginaVeiculos />;
       case 'configuracoes':
         return <PaginaConfiguracoes onMudarPagina={setPaginaAtiva} />;
       default:

--- a/components/LayoutPrincipal.tsx
+++ b/components/LayoutPrincipal.tsx
@@ -5,13 +5,16 @@ import {
   Calendar, 
   CreditCard, 
   AlertTriangle, 
-  MessageCircle, 
+  MessageCircle,
   ShoppingBag,
   BarChart3,
   FileText,
   TrendingUp,
   Star,
   Users,
+  UserPlus,
+  PawPrint,
+  Car,
   Settings,
   LogOut,
   Building2,
@@ -41,6 +44,9 @@ export function LayoutPrincipal({ children, paginaAtiva, onMudarPagina }: Layout
     { id: 'boletos', label: 'Boletos', icone: CreditCard, badge: 2 },
     { id: 'ocorrencias', label: 'Ocorrências', icone: AlertTriangle },
     { id: 'chat', label: 'Chat Portaria', icone: MessageCircle },
+    { id: 'visitantes', label: 'Visitantes', icone: UserPlus },
+    { id: 'pets', label: 'Pets', icone: PawPrint },
+    { id: 'veiculos', label: 'Veículos', icone: Car },
     { id: 'marketplace', label: 'Marketplace', icone: ShoppingBag }
   ];
 
@@ -51,6 +57,9 @@ export function LayoutPrincipal({ children, paginaAtiva, onMudarPagina }: Layout
     { id: 'relatorios', label: 'Relatórios', icone: TrendingUp },
     { id: 'avaliacao', label: 'Avaliações', icone: Star },
     { id: 'usuarios', label: 'Usuários', icone: Users },
+    { id: 'visitantes', label: 'Visitantes', icone: UserPlus },
+    { id: 'pets', label: 'Pets', icone: PawPrint },
+    { id: 'veiculos', label: 'Veículos', icone: Car },
     { id: 'comunicados', label: 'Comunicados', icone: MessageSquare },
     { id: 'reservas', label: 'Reservas', icone: Calendar },
     { id: 'ocorrencias', label: 'Ocorrências', icone: AlertTriangle, badge: 5 }

--- a/components/paginas/PaginaPets.tsx
+++ b/components/paginas/PaginaPets.tsx
@@ -1,0 +1,182 @@
+import { useState } from 'react';
+import { Search, Plus, PawPrint, Trash2 } from 'lucide-react';
+import { Button } from '../ui/button';
+import { Input } from '../ui/input';
+import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '../ui/dialog';
+import { Label } from '../ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table';
+
+interface Pet {
+  id: string;
+  nome: string;
+  especie: 'cachorro' | 'gato' | 'outro';
+  raca: string;
+  apartamento: string;
+  morador: string;
+}
+
+const petsMock: Pet[] = [
+  {
+    id: '1',
+    nome: 'Rex',
+    especie: 'cachorro',
+    raca: 'Vira-lata',
+    apartamento: '101',
+    morador: 'João da Silva'
+  },
+  {
+    id: '2',
+    nome: 'Mimi',
+    especie: 'gato',
+    raca: 'Siames',
+    apartamento: '202',
+    morador: 'Maria Oliveira'
+  }
+];
+
+export function PaginaPets() {
+  const [pets, setPets] = useState(petsMock);
+  const [busca, setBusca] = useState('');
+  const [modalAberto, setModalAberto] = useState(false);
+  const [novoPet, setNovoPet] = useState({
+    nome: '',
+    especie: 'cachorro',
+    raca: '',
+    apartamento: '',
+    morador: ''
+  });
+
+  const petsFiltrados = pets.filter(p =>
+    p.nome.toLowerCase().includes(busca.toLowerCase()) ||
+    p.apartamento.includes(busca) ||
+    p.morador.toLowerCase().includes(busca.toLowerCase())
+  );
+
+  const handleAdicionar = () => {
+    if (novoPet.nome && novoPet.apartamento) {
+      const pet: Pet = {
+        id: (pets.length + 1).toString(),
+        nome: novoPet.nome,
+        especie: novoPet.especie as 'cachorro' | 'gato' | 'outro',
+        raca: novoPet.raca,
+        apartamento: novoPet.apartamento,
+        morador: novoPet.morador
+      };
+      setPets([...pets, pet]);
+      setModalAberto(false);
+      setNovoPet({ nome: '', especie: 'cachorro', raca: '', apartamento: '', morador: '' });
+    }
+  };
+
+  const handleExcluir = (id: string) => {
+    setPets(prev => prev.filter(p => p.id !== id));
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-semibold mb-2">Cadastro de Pets</h2>
+          <p className="text-muted-foreground">Gerencie os animais de estimação dos moradores</p>
+        </div>
+        <Dialog open={modalAberto} onOpenChange={setModalAberto}>
+          <DialogTrigger asChild>
+            <Button className="gap-2">
+              <Plus className="h-4 w-4" />
+              Novo Pet
+            </Button>
+          </DialogTrigger>
+          <DialogContent className="sm:max-w-md">
+            <DialogHeader>
+              <DialogTitle>Novo Pet</DialogTitle>
+            </DialogHeader>
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="nome">Nome</Label>
+                <Input id="nome" value={novoPet.nome} onChange={e => setNovoPet({ ...novoPet, nome: e.target.value })} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="especie">Espécie</Label>
+                <Select value={novoPet.especie} onValueChange={v => setNovoPet({ ...novoPet, especie: v as any })}>
+                  <SelectTrigger id="especie">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="cachorro">Cachorro</SelectItem>
+                    <SelectItem value="gato">Gato</SelectItem>
+                    <SelectItem value="outro">Outro</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="raca">Raça</Label>
+                <Input id="raca" value={novoPet.raca} onChange={e => setNovoPet({ ...novoPet, raca: e.target.value })} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="apartamento">Apartamento</Label>
+                <Input id="apartamento" value={novoPet.apartamento} onChange={e => setNovoPet({ ...novoPet, apartamento: e.target.value })} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="morador">Morador Responsável</Label>
+                <Input id="morador" value={novoPet.morador} onChange={e => setNovoPet({ ...novoPet, morador: e.target.value })} />
+              </div>
+              <Button onClick={handleAdicionar} className="w-full">Salvar</Button>
+            </div>
+          </DialogContent>
+        </Dialog>
+      </div>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <div className="flex items-center justify-between">
+            <CardTitle>Pets Cadastrados</CardTitle>
+            <div className="relative w-full max-w-xs">
+              <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+              <Input
+                placeholder="Buscar"
+                className="pl-8"
+                value={busca}
+                onChange={e => setBusca(e.target.value)}
+              />
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Nome</TableHead>
+                <TableHead>Espécie</TableHead>
+                <TableHead>Raça</TableHead>
+                <TableHead>Apto</TableHead>
+                <TableHead>Morador</TableHead>
+                <TableHead className="w-16"></TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {petsFiltrados.map(pet => (
+                <TableRow key={pet.id}>
+                  <TableCell className="font-medium flex items-center gap-2">
+                    <PawPrint className="h-4 w-4" />
+                    {pet.nome}
+                  </TableCell>
+                  <TableCell className="capitalize">{pet.especie}</TableCell>
+                  <TableCell>{pet.raca}</TableCell>
+                  <TableCell>{pet.apartamento}</TableCell>
+                  <TableCell>{pet.morador}</TableCell>
+                  <TableCell>
+                    <Button size="sm" variant="ghost" onClick={() => handleExcluir(pet.id)}>
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/paginas/PaginaVeiculos.tsx
+++ b/components/paginas/PaginaVeiculos.tsx
@@ -1,0 +1,173 @@
+import { useState } from 'react';
+import { Search, Plus, Car, Trash2 } from 'lucide-react';
+import { Button } from '../ui/button';
+import { Input } from '../ui/input';
+import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '../ui/dialog';
+import { Label } from '../ui/label';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table';
+
+interface Veiculo {
+  id: string;
+  modelo: string;
+  placa: string;
+  cor: string;
+  apartamento: string;
+  morador: string;
+}
+
+const veiculosMock: Veiculo[] = [
+  {
+    id: '1',
+    modelo: 'Honda Civic',
+    placa: 'ABC-1234',
+    cor: 'Prata',
+    apartamento: '101',
+    morador: 'João da Silva'
+  },
+  {
+    id: '2',
+    modelo: 'Toyota Corolla',
+    placa: 'DEF-5678',
+    cor: 'Preto',
+    apartamento: '202',
+    morador: 'Maria Oliveira'
+  }
+];
+
+export function PaginaVeiculos() {
+  const [veiculos, setVeiculos] = useState(veiculosMock);
+  const [busca, setBusca] = useState('');
+  const [modalAberto, setModalAberto] = useState(false);
+  const [novoVeiculo, setNovoVeiculo] = useState({
+    modelo: '',
+    placa: '',
+    cor: '',
+    apartamento: '',
+    morador: ''
+  });
+
+  const veiculosFiltrados = veiculos.filter(v =>
+    v.modelo.toLowerCase().includes(busca.toLowerCase()) ||
+    v.placa.toLowerCase().includes(busca.toLowerCase()) ||
+    v.apartamento.includes(busca) ||
+    v.morador.toLowerCase().includes(busca.toLowerCase())
+  );
+
+  const handleAdicionar = () => {
+    if (novoVeiculo.modelo && novoVeiculo.placa) {
+      const veiculo: Veiculo = {
+        id: (veiculos.length + 1).toString(),
+        modelo: novoVeiculo.modelo,
+        placa: novoVeiculo.placa,
+        cor: novoVeiculo.cor,
+        apartamento: novoVeiculo.apartamento,
+        morador: novoVeiculo.morador
+      };
+      setVeiculos([...veiculos, veiculo]);
+      setModalAberto(false);
+      setNovoVeiculo({ modelo: '', placa: '', cor: '', apartamento: '', morador: '' });
+    }
+  };
+
+  const handleExcluir = (id: string) => {
+    setVeiculos(prev => prev.filter(v => v.id !== id));
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-semibold mb-2">Cadastro de Veículos</h2>
+          <p className="text-muted-foreground">Gerencie os veículos dos moradores</p>
+        </div>
+        <Dialog open={modalAberto} onOpenChange={setModalAberto}>
+          <DialogTrigger asChild>
+            <Button className="gap-2">
+              <Plus className="h-4 w-4" />
+              Novo Veículo
+            </Button>
+          </DialogTrigger>
+          <DialogContent className="sm:max-w-md">
+            <DialogHeader>
+              <DialogTitle>Novo Veículo</DialogTitle>
+            </DialogHeader>
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="modelo">Modelo</Label>
+                <Input id="modelo" value={novoVeiculo.modelo} onChange={e => setNovoVeiculo({ ...novoVeiculo, modelo: e.target.value })} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="placa">Placa</Label>
+                <Input id="placa" value={novoVeiculo.placa} onChange={e => setNovoVeiculo({ ...novoVeiculo, placa: e.target.value })} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="cor">Cor</Label>
+                <Input id="cor" value={novoVeiculo.cor} onChange={e => setNovoVeiculo({ ...novoVeiculo, cor: e.target.value })} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="apartamento">Apartamento</Label>
+                <Input id="apartamento" value={novoVeiculo.apartamento} onChange={e => setNovoVeiculo({ ...novoVeiculo, apartamento: e.target.value })} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="morador">Morador Responsável</Label>
+                <Input id="morador" value={novoVeiculo.morador} onChange={e => setNovoVeiculo({ ...novoVeiculo, morador: e.target.value })} />
+              </div>
+              <Button onClick={handleAdicionar} className="w-full">Salvar</Button>
+            </div>
+          </DialogContent>
+        </Dialog>
+      </div>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <div className="flex items-center justify-between">
+            <CardTitle>Veículos Cadastrados</CardTitle>
+            <div className="relative w-full max-w-xs">
+              <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+              <Input
+                placeholder="Buscar"
+                className="pl-8"
+                value={busca}
+                onChange={e => setBusca(e.target.value)}
+              />
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Modelo</TableHead>
+                <TableHead>Placa</TableHead>
+                <TableHead>Cor</TableHead>
+                <TableHead>Apto</TableHead>
+                <TableHead>Morador</TableHead>
+                <TableHead className="w-16"></TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {veiculosFiltrados.map(v => (
+                <TableRow key={v.id}>
+                  <TableCell className="font-medium flex items-center gap-2">
+                    <Car className="h-4 w-4" />
+                    {v.modelo}
+                  </TableCell>
+                  <TableCell>{v.placa}</TableCell>
+                  <TableCell>{v.cor}</TableCell>
+                  <TableCell>{v.apartamento}</TableCell>
+                  <TableCell>{v.morador}</TableCell>
+                  <TableCell>
+                    <Button size="sm" variant="ghost" onClick={() => handleExcluir(v.id)}>
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/paginas/PaginaVisitantes.tsx
+++ b/components/paginas/PaginaVisitantes.tsx
@@ -1,0 +1,198 @@
+import { useState } from 'react';
+import { Search, Plus, Check, X, UserPlus, Truck } from 'lucide-react';
+import { Button } from '../ui/button';
+import { Input } from '../ui/input';
+import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
+import { Badge } from '../ui/badge';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '../ui/dialog';
+import { Label } from '../ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table';
+
+interface RegistroVisitante {
+  id: string;
+  nome: string;
+  tipo: 'visitante' | 'entrega';
+  documento: string;
+  apartamento: string;
+  status: 'aguardando' | 'autorizado' | 'negado';
+  dataHora: string;
+}
+
+const registrosMock: RegistroVisitante[] = [
+  {
+    id: '1',
+    nome: 'João da Silva',
+    tipo: 'visitante',
+    documento: 'RG 123456',
+    apartamento: '101',
+    status: 'aguardando',
+    dataHora: '20/05/2025 14:00'
+  },
+  {
+    id: '2',
+    nome: 'Entrega Mercado',
+    tipo: 'entrega',
+    documento: 'Pedido 456',
+    apartamento: '202',
+    status: 'autorizado',
+    dataHora: '20/05/2025 15:30'
+  }
+];
+
+export function PaginaVisitantes() {
+  const [registros, setRegistros] = useState(registrosMock);
+  const [busca, setBusca] = useState('');
+  const [modalAberto, setModalAberto] = useState(false);
+  const [novoRegistro, setNovoRegistro] = useState({
+    nome: '',
+    tipo: 'visitante',
+    documento: '',
+    apartamento: ''
+  });
+
+  const registrosFiltrados = registros.filter(r =>
+    r.nome.toLowerCase().includes(busca.toLowerCase()) ||
+    r.apartamento.includes(busca)
+  );
+
+  const handleAutorizar = (id: string) => {
+    setRegistros(prev => prev.map(r => r.id === id ? { ...r, status: 'autorizado' } : r));
+  };
+
+  const handleNegar = (id: string) => {
+    setRegistros(prev => prev.map(r => r.id === id ? { ...r, status: 'negado' } : r));
+  };
+
+  const handleAdicionar = () => {
+    if (novoRegistro.nome && novoRegistro.apartamento) {
+      const registro: RegistroVisitante = {
+        id: (registros.length + 1).toString(),
+        nome: novoRegistro.nome,
+        tipo: novoRegistro.tipo as 'visitante' | 'entrega',
+        documento: novoRegistro.documento,
+        apartamento: novoRegistro.apartamento,
+        status: 'aguardando',
+        dataHora: new Date().toLocaleString('pt-BR')
+      };
+      setRegistros([...registros, registro]);
+      setModalAberto(false);
+      setNovoRegistro({ nome: '', tipo: 'visitante', documento: '', apartamento: '' });
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-semibold mb-2">Controle de Visitantes</h2>
+          <p className="text-muted-foreground">Autorize visitantes e registre entregas</p>
+        </div>
+        <Dialog open={modalAberto} onOpenChange={setModalAberto}>
+          <DialogTrigger asChild>
+            <Button className="gap-2">
+              <Plus className="h-4 w-4" />
+              Novo Registro
+            </Button>
+          </DialogTrigger>
+          <DialogContent className="sm:max-w-md">
+            <DialogHeader>
+              <DialogTitle>Novo Visitante/Entrega</DialogTitle>
+            </DialogHeader>
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="nome">Nome</Label>
+                <Input id="nome" value={novoRegistro.nome} onChange={e => setNovoRegistro({ ...novoRegistro, nome: e.target.value })} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="tipo">Tipo</Label>
+                <Select value={novoRegistro.tipo} onValueChange={v => setNovoRegistro({ ...novoRegistro, tipo: v as any })}>
+                  <SelectTrigger id="tipo">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="visitante">Visitante</SelectItem>
+                    <SelectItem value="entrega">Entrega</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="documento">Documento</Label>
+                <Input id="documento" value={novoRegistro.documento} onChange={e => setNovoRegistro({ ...novoRegistro, documento: e.target.value })} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="apartamento">Apartamento</Label>
+                <Input id="apartamento" value={novoRegistro.apartamento} onChange={e => setNovoRegistro({ ...novoRegistro, apartamento: e.target.value })} />
+              </div>
+              <Button onClick={handleAdicionar} className="w-full">Salvar</Button>
+            </div>
+          </DialogContent>
+        </Dialog>
+      </div>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <div className="flex items-center justify-between">
+            <CardTitle>Registros Recentes</CardTitle>
+            <div className="relative w-full max-w-xs">
+              <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+              <Input
+                placeholder="Buscar"
+                className="pl-8"
+                value={busca}
+                onChange={e => setBusca(e.target.value)}
+              />
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Nome</TableHead>
+                <TableHead>Tipo</TableHead>
+                <TableHead>Documento</TableHead>
+                <TableHead>Apto</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead className="w-24"></TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {registrosFiltrados.map(registro => (
+                <TableRow key={registro.id}>
+                  <TableCell className="font-medium">{registro.nome}</TableCell>
+                  <TableCell className="capitalize flex items-center gap-2">
+                    {registro.tipo === 'visitante' ? <UserPlus className="h-4 w-4" /> : <Truck className="h-4 w-4" />}
+                    {registro.tipo}
+                  </TableCell>
+                  <TableCell>{registro.documento}</TableCell>
+                  <TableCell>{registro.apartamento}</TableCell>
+                  <TableCell>
+                    <Badge variant={
+                      registro.status === 'autorizado' ? 'default' :
+                      registro.status === 'negado' ? 'destructive' : 'outline'
+                    }>
+                      {registro.status === 'aguardando' ? 'Aguardando' : registro.status === 'autorizado' ? 'Autorizado' : 'Negado'}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="flex gap-2">
+                    {registro.status === 'aguardando' && (
+                      <>
+                        <Button size="sm" variant="outline" onClick={() => handleAutorizar(registro.id)}>
+                          <Check className="h-4 w-4" />
+                        </Button>
+                        <Button size="sm" variant="outline" onClick={() => handleNegar(registro.id)}>
+                          <X className="h-4 w-4" />
+                        </Button>
+                      </>
+                    )}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add visitor management screen with registration and authorization flow
- create pet and vehicle registry pages
- wire new pages into layout and navigation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: missing module react-day-picker and component type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ba531e3a988333a56320d2ca2dbec2